### PR TITLE
Python Pypresence better integration

### DIFF
--- a/mpv-discordRPC/main.lua
+++ b/mpv-discordRPC/main.lua
@@ -20,8 +20,6 @@ local o = {
 	-- value <= 15 second, because discord-rpc updates every 15 seconds.
 	playlist_info = "yes",
 	-- Valid value to set `playlist_info`: (yes|no)
-	hide_url = "no",
-	-- Valid value to set `hide_url`: (yes|no)
 	loop_info = "yes",
 	-- Valid value to set `loop_info`: (yes|no)
 	cover_art = "yes",
@@ -171,12 +169,9 @@ local function main()
 	local stream = mp.get_property("stream-path")
 	if url ~= nil then
 		-- checking protocol: http, https
-		if string.match(url, "^https?://.*") ~= nil and o.hide_url == "no"  then
+		if string.match(url, "^https?://.*") ~= nil then
 			largeImageKey = "mpv_stream"
 			largeImageText = url
-		elseif o.hide_url == "yes" then
-			largeImageKey = "mpv_stream"
-			-- will use mpv_version set previously
 		end
 		-- checking site: YouTube, Crunchyroll, SoundCloud, LISTEN.moe
 		if string.match(url, "www.youtube.com/watch%?v=([a-zA-Z0-9-_]+)&?.*$") ~= nil or string.match(url, "youtu.be/([a-zA-Z0-9-_]+)&?.*$") ~= nil then

--- a/mpv-discordRPC/python-pypresence.py
+++ b/mpv-discordRPC/python-pypresence.py
@@ -1,56 +1,42 @@
 #!/usr/bin/env python3
 
 import signal
+from pathlib import Path
 import sys
 import time
+import os
 import pypresence
-
+home = str(Path.home())
+print(home)
+print("start")
 client_id = "448016723057049601"
-pid = 9999
-
-todo = str(sys.argv[1]) if len(sys.argv) > 1 else "shutdown"
-state = str(sys.argv[2]) if len(sys.argv) > 2 else "state = (Idle)"
-details = str(sys.argv[3]) if len(sys.argv) > 3 else "details = No file"
-start = int(sys.argv[4]) if len(sys.argv) > 4 else int(time.time())
-end = int(sys.argv[5]) if len(sys.argv) > 5 else int(time.time() + 60)
-large_image = str(sys.argv[6]) if len(sys.argv) > 6 else "mpv"
-large_text = str(sys.argv[7]) if len(sys.argv) > 7 else "large_text = mpv Media Player"
-small_image = str(sys.argv[8]) if len(sys.argv) > 8 else "player_stop"
-small_text = str(sys.argv[9]) if len(sys.argv) > 9 else "small_text = Idle"
-periodic_timer = int(sys.argv[10]) if len(sys.argv) > 10 else 15
-
-TimeoutHandler = Exception
-
-def timeout_handler(num, stack):
-	raise TimeoutHandler
-
-try:
-	RPC = pypresence.Presence(client_id)
-	RPC.connect()
-	#print("pypresence: RPC connected")
-	signal.signal(signal.SIGALRM, timeout_handler)
-	signal.alarm(periodic_timer)
+RPC = pypresence.Presence(client_id)
+RPC.connect()
+print("pypresence: RPC connected")
+while True:
+	time.sleep(4)
+	pid = 9999
+	file = open("/dev/shm/testfile.txt").read().splitlines()
+	todo = str(file[1]) if len(file) > 1 else "shutdown"
+	state = str(file[2]) if len(file) > 2 else "state = (Idle)"
+	details = str(file[3]) if len(file) > 3 else "details = No file"
+	start = int(file[4]) if len(file) > 4 else int(time.time())
+	end = int(file[5]) if len(file) > 5 else int(time.time() + 60)
+	large_image = str(file[6]) if len(file) > 6 else "mpv"
+	large_text = str(file[7]) if len(file) > 7 else "large_text = mpv Media Player"
+	small_image = str(file[8]) if len(file) > 8 else "player_stop"
+	small_text = str(file[9]) if len(file) > 9 else "small_text = Idle"
+	periodic_timer = int(file[10]) if len(file) > 10 else 15
 	if todo == "shutdown":
 		RPC.clear()
-		#print("pypresence: RPC cleared")
+		print("pypresence: RPC cleared")
 		RPC.close()
-		#print("pypresence: RPC closed")
+		print("pypresence: RPC closed")
+		os.system('rm -rf "/dev/shm/testfile.txt"')
+		sys.exit()
 	elif todo == "idle":
 		RPC.update(state=state, details=details, start=start, large_image=large_image, large_text=large_text, small_image=small_image, small_text=small_text)
-		#print("pypresence: RPC updated.")
-		time.sleep(periodic_timer)
+		print("pypresence: RPC updated.")
 	elif todo == "not-idle":
 		RPC.update(state=state, details=details, end=end, large_image=large_image, large_text=large_text, small_image=small_image, small_text=small_text)
-		#print("pypresence: RPC updated")
-		time.sleep(periodic_timer)
-except (KeyboardInterrupt, SystemExit):
-	#print("  interupt: KeyboardInterrupt|SystemExit)")
-	sys.exit()
-except (BrokenPipeError, IOError):
-	#print("  interupt: BrokenPipeError|IOError")
-	sys.exit()
-except (TimeoutHandler):
-	#print("  interupt: TimeoutHandler")
-	sys.exit()
-except:
-	sys.exit()
+		print("pypresence: RPC updated")


### PR DESCRIPTION
Hi! It's difficult to get two languages to work together in harmony but I think I have a solution that would allow more people to use this plugin. I was having a problem where your plugin would clog up discord by opening too many instances of python at once and not closing them properly. But my solution allows for python to only be opened once, and then closed only when mpv is finished. It makes lua write to a plain text file in /dev/shm (A linux directory that writes directly to RAM) and then have python read that file every 4 seconds (to avoid asyncio problems) and update discord accordingly. At the moment my implementation only works with Linux because /dev/shm doesn't exist in Windows. But that directory should be able to be easily replaced by a variable in the config file (I don't know how those work yet so I couldn't implement it).